### PR TITLE
Add ninja to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ test = [
   "pip @ git+https://github.com/mgorny/pip@freethreading-limited-api",
   "pytest >= 9.0",
   "pytest-xdist",
+  "ninja",  # needed by meson
   { include-group = "backends" },
   { include-group = "build-tools" },
 ]


### PR DESCRIPTION
This lets the tox tests pass out-of-the-box for me on my Mac, which doesn't happen to have a system-wide ninja install.