### PR TITLE
pass tox positional arguments to pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ skipsdist = true
 
 [tool.tox.env_run_base]
 commands = [
-  ["pytest", "-n", "auto"],
+  ["pytest", { replace = "posargs", default = ["-n", "auto"], extend = true } ],
 ]
 dependency_groups = ["test"]
 set_env = { NO_CYTHON_COMPILE = "true" }


### PR DESCRIPTION
This lets me do things like `tox -e py -- -xv` to override the default use of pytest-xdist and pass other arguments to pytest.