### PR TITLE
Update for Python 3.15.0a8 and recent ecosystem progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ Elsewhere, hacks are employed, or the packages are as close to the new
 API as currently possible.
 
 - In packages using the C API, the new limited API is enabled via
-  setting `-D_Py_OPAQUE_PYOBJECT` as required by Python 3.15.0 alphas.
-  According to PEP 803, the final implementation should not require
-  this.  This is also done on packages that have explicit switches for
+  setting `-DPy_TARGET_ABI3T=0x30f0000` as described in PEP 803.
+  This is also done on some packages that have explicit switches for
   limited API, since these do not account for PEP 803.
 - A minimal [fork of
   meson-python](https://github.com/mgorny/meson-python/tree/freethreading-limited-api)
@@ -27,9 +26,9 @@ API as currently possible.
 - [A preview freethreading-limited-api branch of
   Cython](https://github.com/cython/cython/tree/freethreading-limited-api-preview)
   is used.
-- PyO3 does not support PEP 793 or PEP 803 yet.  The test
-  currently builds a limited API extension targeting Python 3.14.
-  [PyO3#5786](https://github.com/PyO3/pyo3/issues/5786).
+- Forks of [PyO3](https://github.com/PyO3/pyo3/pull/5807) and
+  [maturin](https://github.com/PyO3/maturin/pull/3113) are used that add
+  preliminary PEP 803 support.
 - nanobind has preliminary support for PEP 793 and PEP 803 in the [`abi3t`
   branch](https://github.com/wjakob/nanobind/compare/master...abi3t).  The test
   package uses regular limited API or freethreading API currently.
@@ -39,8 +38,6 @@ API as currently possible.
 - A minimal [fork of CFFI](https://github.com/python-cffi/cffi/pull/232) is
   used, to bypass code paths that do not allow limited API builds on the
   free-threaded build.
-- A minimal [fork of packaging](https://github.com/pypa/packaging/pull/1099) is
-  used, to add support for the `abi3t` ABI tag.
 - A minimal [fork of setuptools](https://github.com/pypa/setuptools/pull/5193)
   is used, to add support for the `abi3t` ABI tag and `abi3.abi3t` compressed
   tag set.

--- a/common/rust/Cargo.lock
+++ b/common/rust/Cargo.lock
@@ -44,9 +44,8 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+version = "0.28.3"
+source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#f326c74c72df755d565eef5dd858253130631442"
 dependencies = [
  "libc",
  "once_cell",
@@ -58,18 +57,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+version = "0.28.3"
+source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#f326c74c72df755d565eef5dd858253130631442"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+version = "0.28.3"
+source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#f326c74c72df755d565eef5dd858253130631442"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -77,9 +74,8 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+version = "0.28.3"
+source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#f326c74c72df755d565eef5dd858253130631442"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -89,13 +85,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+version = "0.28.3"
+source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#f326c74c72df755d565eef5dd858253130631442"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/common/rust/Cargo.toml
+++ b/common/rust/Cargo.toml
@@ -8,5 +8,4 @@ name = "limited"
 crate-type = ["cdylib"]
 
 [dependencies]
-# TODO: update to py315 (or pep803?) when supported
-pyo3 = { version = "0.28.2", features = ["abi3-py314"] }
+pyo3 = { git = "https://github.com/ngoldbaum/pyo3", branch = "opaque-pyobject", features = ["abi3t-py315"] }

--- a/meson-python/c/meson.build
+++ b/meson-python/c/meson.build
@@ -9,5 +9,5 @@ ext_mod_limited = py.extension_module('limited',
   'limited.c',
   limited_api: '3.15',
   install: true,
-  c_args: ['-D_Py_OPAQUE_PYOBJECT'],
+  c_args: ['-DPy_TARGET_ABI3T=0x030f0000'],
 )

--- a/meson-python/cython/meson.build
+++ b/meson-python/cython/meson.build
@@ -9,5 +9,5 @@ ext_mod_limited = py.extension_module('limited',
   'limited.pyx',
   limited_api: '3.15',
   install: true,
-  c_args: ['-D_Py_OPAQUE_PYOBJECT'],
+  c_args: ['-DPy_TARGET_ABI3T=0x030f0000'],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [dependency-groups]
 backends = [
-  "maturin",
+  "maturin @ git+https://github.com/ngoldbaum/maturin@abi3t",
+  "meson @ git+https://github.com/mgorny/meson@pep803",
   "meson-python @ git+https://github.com/mgorny/meson-python@freethreading-limited-api",
   "scikit-build-core",
   "setuptools @ git+https://github.com/ngoldbaum/setuptools@abi3.abi3t",
-  "packaging @ git+https://github.com/ngoldbaum/packaging@abi3.abi3t",
   "cffi @ git+https://github.com/ngoldbaum/cffi@abi3t.abi3",
 ]
 build-tools = [
@@ -14,7 +14,7 @@ build-tools = [
 ]
 test = [
   "build",
-  "pip @ git+https://github.com/mgorny/pip@freethreading-limited-api",
+  "pip @ git+https://github.com/pypa/pip",
   "pytest >= 9.0",
   "pytest-xdist",
   "ninja",  # needed by meson

--- a/scikit-build-core/c/CMakeLists.txt
+++ b/scikit-build-core/c/CMakeLists.txt
@@ -10,5 +10,5 @@ Python_add_library(
   USE_SABI 3.15
   limited.c
 )
-target_compile_definitions(limited PRIVATE -D_Py_OPAQUE_PYOBJECT)
+target_compile_definitions(limited PRIVATE -DPy_TARGET_ABI3T=0x030f0000)
 install(TARGETS limited DESTINATION ${SKBUILD_PLATLIB_DIR})

--- a/scikit-build-core/cython/CMakeLists.txt
+++ b/scikit-build-core/cython/CMakeLists.txt
@@ -13,5 +13,5 @@ Python_add_library(
   USE_SABI 3.15
   ${limited_c}
 )
-target_compile_definitions(limited PRIVATE -D_Py_OPAQUE_PYOBJECT)
+target_compile_definitions(limited PRIVATE -DPy_TARGET_ABI3T=0x030f0000)
 install(TARGETS limited DESTINATION ${SKBUILD_PLATLIB_DIR})

--- a/scikit-build-core/nanobind/CMakeLists.txt
+++ b/scikit-build-core/nanobind/CMakeLists.txt
@@ -15,5 +15,5 @@ nanobind_add_module(limited
   limited.cxx)
 # TODO: nanobind does not implement PEP 793 / PEP 803 yet
 # https://github.com/wjakob/nanobind/discussions/1187
-#target_compile_definitions(limited PRIVATE -D_Py_OPAQUE_PYOBJECT)
+#target_compile_definitions(limited PRIVATE -DPy_TARGET_ABI3T=0x030f0000)
 install(TARGETS limited DESTINATION ${SKBUILD_PLATLIB_DIR})

--- a/setuptools/c/pyproject.toml
+++ b/setuptools/c/pyproject.toml
@@ -2,7 +2,6 @@
 build-backend = "setuptools.build_meta"
 requires = [
   "setuptools@git+https://github.com/ngoldbaum/setuptools@abi3.abi3t",
-  "packaging@git+https://github.com/ngoldbaum/packaging@abi3.abi3t",
 ]
 
 [project]
@@ -16,5 +15,5 @@ py-limited-api = true
 # define-macros is broken: https://github.com/pypa/setuptools/issues/4810
 extra-compile-args = [
     "-DPy_LIMITED_API=0x030f0000",
-    "-D_Py_OPAQUE_PYOBJECT",
+    "-DPy_TARGET_ABI3T=0x030f0000",
 ]

--- a/setuptools/cffi/pyproject.toml
+++ b/setuptools/cffi/pyproject.toml
@@ -2,7 +2,6 @@
 build-backend = "setuptools.build_meta"
 requires = [
   "setuptools@git+https://github.com/ngoldbaum/setuptools@abi3.abi3t",
-  "packaging@git+https://github.com/ngoldbaum/packaging@abi3.abi3t",
   "cffi@git+https://github.com/ngoldbaum/cffi@abi3t.abi3",
 ]
 

--- a/setuptools/cython/pyproject.toml
+++ b/setuptools/cython/pyproject.toml
@@ -2,7 +2,6 @@
 build-backend = "setuptools.build_meta"
 requires = [
   "setuptools@git+https://github.com/ngoldbaum/setuptools@abi3.abi3t",
-  "packaging@git+https://github.com/ngoldbaum/packaging@abi3.abi3t",
   "cython@git+https://github.com/cython/cython@freethreading-limited-api-preview",
 ]
 
@@ -17,5 +16,5 @@ py-limited-api = true
 # define-macros is broken: https://github.com/pypa/setuptools/issues/4810
 extra-compile-args = [
     "-DPy_LIMITED_API=0x030f0000",
-    "-D_Py_OPAQUE_PYOBJECT",
+    "-DPy_TARGET_ABI3T=0x030f0000",
 ]

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -88,7 +88,7 @@ def test_install(test_case: str, tmp_path: Path, subtests) -> None:
                 assert "abi3" in path_name and "abi3t" not in path_name
         else:
             with subxfail(
-                build_system != "meson-python",
+                build_system not in ("meson-python", "maturin"),
                 reason="Only meson-python and setuptools forks build abi3.abi3t",
             ):
                 assert "abi3.abi3t" in path_name
@@ -114,8 +114,8 @@ def test_install(test_case: str, tmp_path: Path, subtests) -> None:
     if os.name != "nt":
         with subtests.test(msg="extension has .abi3 suffix"):
             with subxfail(
-                IS_FREETHREADING and language in ("nanobind", "rust"),
-                reason="nanobind and PyO3 do not support PEP 803 yet",
+                IS_FREETHREADING and language  == "nanobind",
+                reason="nanobind does not support PEP 803 yet",
             ):
                 subprocess.run([venv_python, "-c", TEST_ABI3], check=True)
 


### PR DESCRIPTION
3.15.0a8 included the PEP 803 implementation, so I replace direct use of `_Py_OPAQUE_PYOBJECT` with `Py_TARGET_ABI3T`.

Packaging 26.1 includes PEP 803 support.

Pip vendored packaging 26.1 already, so we can depend on upstream's repository.

My PyO3 and maturin branches add preliminary PEP 803 support.