### PR TITLE
Update pyo3 dependency to fix Windows build issues

### DIFF
--- a/maturin/rust/Cargo.lock
+++ b/maturin/rust/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "pyo3"
 version = "0.28.3"
-source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#107ab27043ba09452d77a97b8b34c3fbfd92f17f"
+source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#5334eaa1fc79e15f38225f7d297918f9a481bc3c"
 dependencies = [
  "libc",
  "once_cell",
@@ -58,7 +58,7 @@ dependencies = [
 [[package]]
 name = "pyo3-build-config"
 version = "0.28.3"
-source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#107ab27043ba09452d77a97b8b34c3fbfd92f17f"
+source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#5334eaa1fc79e15f38225f7d297918f9a481bc3c"
 dependencies = [
  "target-lexicon",
 ]
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 name = "pyo3-ffi"
 version = "0.28.3"
-source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#107ab27043ba09452d77a97b8b34c3fbfd92f17f"
+source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#5334eaa1fc79e15f38225f7d297918f9a481bc3c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -75,7 +75,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros"
 version = "0.28.3"
-source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#107ab27043ba09452d77a97b8b34c3fbfd92f17f"
+source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#5334eaa1fc79e15f38225f7d297918f9a481bc3c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -86,7 +86,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros-backend"
 version = "0.28.3"
-source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#107ab27043ba09452d77a97b8b34c3fbfd92f17f"
+source = "git+https://github.com/ngoldbaum/pyo3?branch=opaque-pyobject#5334eaa1fc79e15f38225f7d297918f9a481bc3c"
 dependencies = [
  "heck",
  "proc-macro2",


### PR DESCRIPTION
I fixed some issues with my PyO3 branch with manual testing on my Windows machine. This updates the PyO3 dependency to point at a fixed commit.